### PR TITLE
ci: update node version for babel-dual-package.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: '18.16.0'
+          node-version: '20.3.1'
       - name: Install Dependencies
         run: npm ci
       - name: Save error log

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: '18.16.0'
+          node-version: '20.3.1'
       - name: Install Dependencies
         run: npm ci
       - name: Save error log

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "magic-comments",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "magic-comments",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "micromatch": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magic-comments",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Utility for adding webpack magic comments at build time.",
   "type": "module",
   "main": "dist",


### PR DESCRIPTION
* Fix the broken publish because the publish workflow had the wrong node version for `babel-dual-package` (I need to fix that so that v18.x.x is supported)